### PR TITLE
Prepare to new release

### DIFF
--- a/accounting.go
+++ b/accounting.go
@@ -64,10 +64,10 @@ func getBalance(c *cli.Context) error {
 		return err
 	}
 
-	resp, err := accounting.NewAccountingClient(conn).Balance(ctx, &accounting.BalanceRequest{
-		OwnerID: owner,
-		TTL:     getTTL(c),
-	})
+	req := &accounting.BalanceRequest{OwnerID: owner}
+	req.SetTTL(getTTL(c))
+
+	resp, err := accounting.NewAccountingClient(conn).Balance(ctx, req)
 	if err != nil {
 		return errors.Wrap(err, "could not request balance")
 	}

--- a/accounting.go
+++ b/accounting.go
@@ -9,6 +9,7 @@ import (
 	"text/tabwriter"
 	"time"
 
+	crypto "github.com/nspcc-dev/neofs-crypto"
 	"github.com/nspcc-dev/neofs-proto/accounting"
 	"github.com/nspcc-dev/neofs-proto/decimal"
 	"github.com/nspcc-dev/neofs-proto/refs"
@@ -48,7 +49,7 @@ func getBalance(c *cli.Context) error {
 	}
 
 	// Try to receive key from file
-	if key, err = parseKeyValue(keyArg); err != nil {
+	if key, err = crypto.LoadPrivateKey(keyArg); err != nil {
 		return err
 	}
 

--- a/action.go
+++ b/action.go
@@ -54,7 +54,7 @@ type action struct {
 
 var actions = map[actionName]*action{
 	Global: {
-		Flags: []cli.Flag{ttlF, cfgF},
+		Flags: []cli.Flag{ttlF, cfgF, keyFile},
 	},
 
 	// container commands

--- a/config.go
+++ b/config.go
@@ -1,10 +1,7 @@
 package main
 
 import (
-	"crypto/ecdsa"
-	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 
@@ -67,7 +64,7 @@ func setCommand(mode setMode) cli.ActionFunc {
 
 		switch mode {
 		case KeyMode:
-			if _, err := parseKeyValue(value); err != nil {
+			if _, err := crypto.LoadPrivateKey(value); err != nil {
 				fmt.Println(err.Error())
 				os.Exit(2)
 			}
@@ -106,16 +103,4 @@ func parseHostValue(val string) (string, error) {
 	}
 
 	return net.JoinHostPort(addr.IP.String(), port), nil
-}
-
-func parseKeyValue(val string) (*ecdsa.PrivateKey, error) {
-	if data, err := ioutil.ReadFile(val); err == nil {
-		return crypto.UnmarshalPrivateKey(data)
-	} else if data, err = hex.DecodeString(val); err == nil {
-		return crypto.UnmarshalPrivateKey(data)
-	} else if key, err := crypto.WIFDecode(val); err == nil {
-		return key, nil
-	}
-
-	return nil, errors.Errorf("unknown key format (%q), expect: hex-string, wif or file-path", val)
 }

--- a/container.go
+++ b/container.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"code.cloudfoundry.org/bytefmt"
+	crypto "github.com/nspcc-dev/neofs-crypto"
 	"github.com/nspcc-dev/neofs-proto/container"
 	"github.com/nspcc-dev/neofs-proto/object"
 	"github.com/nspcc-dev/neofs-proto/refs"
@@ -87,7 +88,7 @@ func putContainer(c *cli.Context) error {
 	}
 
 	// Try to receive key from file
-	if key, err = parseKeyValue(keyArg); err != nil {
+	if key, err = crypto.LoadPrivateKey(keyArg); err != nil {
 		return err
 	}
 
@@ -253,7 +254,7 @@ func listContainers(c *cli.Context) error {
 	}
 
 	// Try to receive key from file
-	if key, err = parseKeyValue(keyArg); err != nil {
+	if key, err = crypto.LoadPrivateKey(keyArg); err != nil {
 		return err
 	}
 

--- a/container.go
+++ b/container.go
@@ -116,8 +116,9 @@ func putContainer(c *cli.Context) error {
 		Capacity:  cCap * uint64(object.UnitsGB),
 		OwnerID:   owner,
 		Rules:     *plRule,
-		TTL:       getTTL(c),
 	}
+
+	req.SetTTL(getTTL(c))
 
 	if err = service.SignRequest(req, key); err != nil {
 		return errors.Wrap(err, "could not sign request")
@@ -149,10 +150,9 @@ loop:
 		case <-ticker.C:
 			fmt.Printf("...")
 
-			resp, err := client.List(ctx, &container.ListRequest{
-				OwnerID: owner,
-				TTL:     getTTL(c),
-			})
+			req := &container.ListRequest{OwnerID: owner}
+			req.SetTTL(getTTL(c))
+			resp, err := client.List(ctx, req)
 			if err != nil {
 				continue loop
 			}
@@ -191,7 +191,10 @@ func getContainer(c *cli.Context) error {
 		return errors.Wrapf(err, "can't connect to host '%s'", host)
 	}
 
-	resp, err := container.NewServiceClient(conn).Get(ctx, &container.GetRequest{CID: cid, TTL: getTTL(c)})
+	req := &container.GetRequest{CID: cid}
+	req.SetTTL(getTTL(c))
+
+	resp, err := container.NewServiceClient(conn).Get(ctx, req)
 	if err != nil {
 		return errors.Wrap(err, "can't perform request")
 	}
@@ -226,7 +229,9 @@ func delContainer(c *cli.Context) error {
 		return errors.Wrapf(err, "can't connect to host '%s'", host)
 	}
 
-	_, err = container.NewServiceClient(conn).Delete(ctx, &container.DeleteRequest{CID: cid, TTL: getTTL(c)})
+	req := &container.DeleteRequest{CID: cid}
+	req.SetTTL(getTTL(c))
+	_, err = container.NewServiceClient(conn).Delete(ctx, req)
 
 	return errors.Wrap(err, "can't perform request")
 }
@@ -264,10 +269,9 @@ func listContainers(c *cli.Context) error {
 		return errors.Wrap(err, "could not compute owner ID")
 	}
 
-	resp, err := container.NewServiceClient(conn).List(ctx, &container.ListRequest{
-		OwnerID: owner,
-		TTL:     getTTL(c),
-	})
+	req := &container.ListRequest{OwnerID: owner}
+	req.SetTTL(getTTL(c))
+	resp, err := container.NewServiceClient(conn).List(ctx, req)
 	if err != nil {
 		return errors.Wrapf(err, "can't complete request")
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.13
 require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20190819182555-854d396b647c
 	github.com/mr-tron/base58 v1.1.2
-	github.com/nspcc-dev/neofs-crypto v0.2.1
-	github.com/nspcc-dev/neofs-proto v0.1.0
+	github.com/nspcc-dev/neofs-crypto v0.2.2
+	github.com/nspcc-dev/neofs-proto v0.2.1
 	github.com/nspcc-dev/netmap v1.6.1
 	github.com/nspcc-dev/netmap-ql v1.2.0
 	github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -108,10 +108,10 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/nspcc-dev/hrw v1.0.1/go.mod h1:2gbvQ0nRi9+er+djibFyMLMWC8Ilwe7Z9pYCU6OrkMM=
 github.com/nspcc-dev/hrw v1.0.8 h1:vwRuJXZXgkMvf473vFzeWGCfY1WBVeSHAEHvR4u3/Cg=
 github.com/nspcc-dev/hrw v1.0.8/go.mod h1:l/W2vx83vMQo6aStyx2AuZrJ+07lGv2JQGlVkPG06MU=
-github.com/nspcc-dev/neofs-crypto v0.2.1 h1:NxKexcW88vlHO/u7EYjx5Q1UaOQ7XhYrCsLSVgOcCxw=
-github.com/nspcc-dev/neofs-crypto v0.2.1/go.mod h1:F/96fUzPM3wR+UGsPi3faVNmFlA9KAEAUQR7dMxZmNA=
-github.com/nspcc-dev/neofs-proto v0.1.0 h1:CloznEFNGhHrGR6MSsAREJOSpEGWBsJOmezLArJbfFo=
-github.com/nspcc-dev/neofs-proto v0.1.0/go.mod h1:dUbMyURyTeGx4tBz/Cz/ccsvQA6TRcNR1+EDB93Y4jA=
+github.com/nspcc-dev/neofs-crypto v0.2.2 h1:jLc5O+Wdpaq7L4lNYFX7li+OP4I1FsvvcPW1NXm3erY=
+github.com/nspcc-dev/neofs-crypto v0.2.2/go.mod h1:F/96fUzPM3wR+UGsPi3faVNmFlA9KAEAUQR7dMxZmNA=
+github.com/nspcc-dev/neofs-proto v0.2.1 h1:Y9m4iq0cQLkLkG8zFtmVlQjIoeFfOFm+ZtA9QUnH4pA=
+github.com/nspcc-dev/neofs-proto v0.2.1/go.mod h1:yBSZB95g04EOK2XkV/Iibzv33aXwqsLp3Xwmvehljao=
 github.com/nspcc-dev/netmap v1.2.0/go.mod h1:9vt5vDTHP0BdhUluQek4iFfMv+pCv5b1Kg7eM6WyQl8=
 github.com/nspcc-dev/netmap v1.6.1 h1:Pigqpqi6QSdRiusbq5XlO20A18k6Eyu7j9MzOfAE3CM=
 github.com/nspcc-dev/netmap v1.6.1/go.mod h1:mhV3UOg9ljQmu0teQShD6+JYX09XY5gu2I4hIByCH9M=

--- a/object.go
+++ b/object.go
@@ -181,15 +181,16 @@ func del(c *cli.Context) error {
 		return errors.Wrap(err, "could not compute owner ID")
 	}
 
-	_, err = object.NewServiceClient(conn).Delete(ctx, &object.DeleteRequest{
+	req := &object.DeleteRequest{
 		Address: refs.Address{
 			CID:      cid,
 			ObjectID: objID,
 		},
 		OwnerID: owner,
-		TTL:     getTTL(c),
 		Token:   token,
-	})
+	}
+	req.SetTTL(getTTL(c))
+	_, err = object.NewServiceClient(conn).Delete(ctx, req)
 	if err != nil {
 		return errors.Wrap(err, "can't perform DELETE request")
 	}
@@ -232,14 +233,15 @@ func head(c *cli.Context) error {
 		return errors.Wrapf(err, "can't connect to host '%s'", host)
 	}
 
-	resp, err := object.NewServiceClient(conn).Head(ctx, &object.HeadRequest{
+	req := &object.HeadRequest{
 		Address: refs.Address{
 			CID:      cid,
 			ObjectID: objID,
 		},
 		FullHeaders: fh,
-		TTL:         getTTL(c),
-	})
+	}
+	req.SetTTL(getTTL(c))
+	resp, err := object.NewServiceClient(conn).Head(ctx, req)
 	if err != nil {
 		return errors.Wrap(err, "can't perform HEAD request")
 	}
@@ -322,12 +324,13 @@ func search(c *cli.Context) error {
 		return errors.Wrapf(err, "can't connect to host '%s'", host)
 	}
 
-	resp, err := object.NewServiceClient(conn).Search(ctx, &object.SearchRequest{
-		ContainerID: cid,
-		Query:       data,
-		TTL:         getTTL(c),
-		Version:     1,
-	})
+	sreq := &object.SearchRequest{
+		ContainerID:  cid,
+		Query:        data,
+		QueryVersion: 1,
+	}
+	sreq.SetTTL(getTTL(c))
+	resp, err := object.NewServiceClient(conn).Search(ctx, sreq)
 	if err != nil {
 		return errors.Wrap(err, "can't perform SEARCH request")
 	}
@@ -381,14 +384,15 @@ func getRange(c *cli.Context) error {
 		return errors.Wrapf(err, "can't connect to host '%s'", host)
 	}
 
-	resp, err := object.NewServiceClient(conn).GetRange(ctx, &object.GetRangeRequest{
+	req := &object.GetRangeRequest{
 		Address: refs.Address{
 			ObjectID: objID,
 			CID:      cid,
 		},
 		Ranges: ranges,
-		TTL:    getTTL(c),
-	})
+	}
+	req.SetTTL(getTTL(c))
+	resp, err := object.NewServiceClient(conn).GetRange(ctx, req)
 	if err != nil {
 		return errors.Wrap(err, "can't perform GETRANGE request")
 	}
@@ -449,15 +453,16 @@ func getRangeHash(c *cli.Context) error {
 		return errors.Wrapf(err, "can't connect to host '%s'", host)
 	}
 
-	resp, err := object.NewServiceClient(conn).GetRangeHash(ctx, &object.GetRangeHashRequest{
+	req := &object.GetRangeHashRequest{
 		Address: refs.Address{
 			ObjectID: objID,
 			CID:      cid,
 		},
 		Ranges: ranges,
 		Salt:   salt,
-		TTL:    getTTL(c),
-	})
+	}
+	req.SetTTL(getTTL(c))
+	resp, err := object.NewServiceClient(conn).GetRangeHash(ctx, req)
 	if err != nil {
 		return errors.Wrap(err, "can't perform GETRANGEHASH request")
 	}
@@ -642,14 +647,15 @@ func put(c *cli.Context) error {
 		fmt.Printf("  ID: %s\n  CID: %s\n", resp.Address.ObjectID, resp.Address.CID)
 		if verify {
 			result := "success"
-			r, err := client.GetRangeHash(ctx, &object.GetRangeHashRequest{
+			req := &object.GetRangeHashRequest{
 				Address: refs.Address{
 					ObjectID: resp.Address.ObjectID,
 					CID:      resp.Address.CID,
 				},
 				Ranges: []object.Range{{Offset: 0, Length: obj.SystemHeader.PayloadLength}},
-				TTL:    getTTL(c),
-			})
+			}
+			req.SetTTL(getTTL(c))
+			r, err := client.GetRangeHash(ctx, req)
 			if err != nil {
 				result = "can't perform GETRANGEHASH request"
 			} else if len(r.Hashes) == 0 {
@@ -773,13 +779,14 @@ func get(c *cli.Context) error {
 		return errors.Wrapf(err, "can't connect to host '%s'", host)
 	}
 
-	getClient, err := object.NewServiceClient(conn).Get(ctx, &object.GetRequest{
+	req := &object.GetRequest{
 		Address: refs.Address{
 			ObjectID: oid,
 			CID:      cid,
 		},
-		TTL: getTTL(c),
-	})
+	}
+	req.SetTTL(getTTL(c))
+	getClient, err := object.NewServiceClient(conn).Get(ctx, req)
 	if err != nil {
 		return errors.Wrap(err, "get command failed on client creation")
 	}

--- a/object.go
+++ b/object.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"code.cloudfoundry.org/bytefmt"
+	crypto "github.com/nspcc-dev/neofs-crypto"
 	"github.com/nspcc-dev/neofs-proto/hash"
 	"github.com/nspcc-dev/neofs-proto/object"
 	"github.com/nspcc-dev/neofs-proto/query"
@@ -147,7 +148,7 @@ func del(c *cli.Context) error {
 	}
 
 	// Try to receive key from file
-	if key, err = parseKeyValue(keyArg); err != nil {
+	if key, err = crypto.LoadPrivateKey(keyArg); err != nil {
 		return err
 	}
 
@@ -542,7 +543,7 @@ func put(c *cli.Context) error {
 	}
 
 	// Try to receive key from file
-	if key, err = parseKeyValue(keyArg); err != nil {
+	if key, err = crypto.LoadPrivateKey(keyArg); err != nil {
 		return err
 	}
 

--- a/status.go
+++ b/status.go
@@ -41,6 +41,7 @@ func getMetrics(c *cli.Context) error {
 	var (
 		err  error
 		conn *grpc.ClientConn
+		req  = new(state.MetricsRequest)
 		host = c.Parent().String(hostFlag)
 	)
 
@@ -58,8 +59,10 @@ func getMetrics(c *cli.Context) error {
 		return errors.Wrapf(err, "could not connect to host %s", host)
 	}
 
-	client := state.NewStatusClient(conn)
-	res, err := client.Metrics(ctx, new(state.MetricsRequest))
+	setTTL(c, req)
+	signRequest(c, req)
+
+	res, err := state.NewStatusClient(conn).Metrics(ctx, req)
 	if err != nil {
 		return errors.Wrap(err, "status command failed on remote call")
 	}
@@ -85,6 +88,7 @@ func getHealthy(c *cli.Context) error {
 	var (
 		err  error
 		conn *grpc.ClientConn
+		req  = new(state.HealthRequest)
 		host = c.Parent().String(hostFlag)
 	)
 
@@ -102,8 +106,10 @@ func getHealthy(c *cli.Context) error {
 		return errors.Wrapf(err, "could not connect to host %s", host)
 	}
 
-	client := state.NewStatusClient(conn)
-	res, err := client.HealthCheck(ctx, new(state.HealthRequest))
+	setTTL(c, req)
+	signRequest(c, req)
+
+	res, err := state.NewStatusClient(conn).HealthCheck(ctx, req)
 	if err != nil {
 		return errors.Wrap(err, "status command failed on remote call")
 	}
@@ -117,6 +123,7 @@ func getEpoch(c *cli.Context) error {
 	var (
 		err  error
 		conn *grpc.ClientConn
+		req  = new(state.NetmapRequest)
 		host = c.Parent().String(hostFlag)
 	)
 
@@ -134,8 +141,10 @@ func getEpoch(c *cli.Context) error {
 		return errors.Wrapf(err, "could not connect to host %s", host)
 	}
 
-	client := state.NewStatusClient(conn)
-	nm, err := client.Netmap(ctx, new(state.NetmapRequest))
+	setTTL(c, req)
+	signRequest(c, req)
+
+	nm, err := state.NewStatusClient(conn).Netmap(ctx, req)
 	if err != nil {
 		return errors.Wrap(err, "status command failed on remote call")
 	}
@@ -148,6 +157,7 @@ func getNetmap(c *cli.Context) error {
 	var (
 		err  error
 		conn *grpc.ClientConn
+		req  = new(state.NetmapRequest)
 		host = c.Parent().String(hostFlag)
 	)
 
@@ -165,8 +175,10 @@ func getNetmap(c *cli.Context) error {
 		return errors.Wrapf(err, "could not connect to host %s", host)
 	}
 
-	client := state.NewStatusClient(conn)
-	nm, err := client.Netmap(ctx, new(state.NetmapRequest))
+	setTTL(c, req)
+	signRequest(c, req)
+
+	nm, err := state.NewStatusClient(conn).Netmap(ctx, req)
 	if err != nil {
 		return errors.Wrap(err, "status command failed on remote call")
 	}

--- a/storagegroup.go
+++ b/storagegroup.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"time"
 
+	crypto "github.com/nspcc-dev/neofs-crypto"
 	"github.com/nspcc-dev/neofs-proto/object"
 	"github.com/nspcc-dev/neofs-proto/refs"
 	"github.com/nspcc-dev/neofs-proto/session"
@@ -91,7 +92,7 @@ func putSG(c *cli.Context) error {
 	}
 
 	// Try to receive key from file
-	if key, err = parseKeyValue(keyArg); err != nil {
+	if key, err = crypto.LoadPrivateKey(keyArg); err != nil {
 		return err
 	}
 

--- a/storagegroup.go
+++ b/storagegroup.go
@@ -2,12 +2,10 @@ package main
 
 import (
 	"context"
-	"crypto/ecdsa"
 	"fmt"
 	"math"
 	"time"
 
-	crypto "github.com/nspcc-dev/neofs-crypto"
 	"github.com/nspcc-dev/neofs-proto/object"
 	"github.com/nspcc-dev/neofs-proto/refs"
 	"github.com/nspcc-dev/neofs-proto/session"
@@ -41,7 +39,6 @@ var (
 	putSGAction = &action{
 		Action: putSG,
 		Flags: []cli.Flag{
-			keyFile,
 			containerID,
 			objectIDs,
 		},
@@ -74,25 +71,19 @@ func delSG(c *cli.Context) error {
 func putSG(c *cli.Context) error {
 	var (
 		err  error
-		key  *ecdsa.PrivateKey
+		key  = getKey(c)
 		conn *grpc.ClientConn
 		cid  refs.CID
 		oids []refs.ObjectID
 
 		host           = c.Parent().String(hostFlag)
-		keyArg         = c.String(keyFlag)
 		strContainerID = c.String(cidFlag)
 		strObjectIDs   = c.StringSlice(objFlag)
 	)
 
-	if host == "" || keyArg == "" {
+	if host == "" {
 		return errors.Errorf("invalid input\nUsage: %s", c.Command.UsageText)
 	} else if host, err = parseHostValue(host); err != nil {
-		return err
-	}
-
-	// Try to receive key from file
-	if key, err = crypto.LoadPrivateKey(keyArg); err != nil {
 		return err
 	}
 
@@ -151,10 +142,15 @@ func putSG(c *cli.Context) error {
 
 	sg.SystemHeader.ID = objID
 
-	token, err := establishSession(ctx, conn, key, &session.Token{
-		ObjectID:   []refs.ObjectID{objID},
-		FirstEpoch: 0,
-		LastEpoch:  math.MaxUint64,
+	token, err := establishSession(ctx, sessionParams{
+		cmd:  c,
+		key:  key,
+		conn: conn,
+		token: &session.Token{
+			// FirstEpoch: 0,
+			ObjectID:  []refs.ObjectID{objID},
+			LastEpoch: math.MaxUint64,
+		},
 	})
 	if err != nil {
 		return errors.Wrap(err, "can't establish session")
@@ -166,7 +162,11 @@ func putSG(c *cli.Context) error {
 		return errors.Wrap(err, "put command failed on client creation")
 	}
 
-	if err = putClient.Send(object.MakePutRequestHeader(sg, 0, getTTL(c), token)); err != nil {
+	req := object.MakePutRequestHeader(sg, token)
+	setTTL(c, req)
+	signRequest(c, req)
+
+	if err = putClient.Send(req); err != nil {
 		return errors.Wrap(err, "storage group put command failed on Send SG origin")
 	}
 

--- a/withdraw.go
+++ b/withdraw.go
@@ -106,8 +106,8 @@ func putWithdraw(c *cli.Context) error {
 		Amount:    dec,
 		Height:    blockHeight,
 		MessageID: msgID,
-		TTL:       getTTL(c),
 	}
+	req.SetTTL(getTTL(c))
 
 	if err = service.SignRequest(req, key); err != nil {
 		return errors.Wrap(err, "could not sign request")
@@ -157,11 +157,12 @@ func getWithdraw(c *cli.Context) error {
 		return errors.Wrap(err, "could not compute owner ID")
 	}
 
-	resp, err := accounting.NewWithdrawClient(conn).Get(ctx, &accounting.GetRequest{
+	req := &accounting.GetRequest{
 		ID:      accounting.ChequeID(wid),
 		OwnerID: owner,
-		TTL:     getTTL(c),
-	})
+	}
+	req.SetTTL(getTTL(c))
+	resp, err := accounting.NewWithdrawClient(conn).Get(ctx, req)
 	if err != nil {
 		return errors.Wrap(err, "can't perform request")
 	}
@@ -266,8 +267,8 @@ func delWithdraw(c *cli.Context) error {
 		ID:        accounting.ChequeID(wid),
 		OwnerID:   owner,
 		MessageID: msgID,
-		TTL:       getTTL(c),
 	}
+	req.SetTTL(getTTL(c))
 
 	if err = service.SignRequest(req, key); err != nil {
 		return errors.Wrap(err, "could not sign request")
@@ -311,10 +312,9 @@ func listWithdraw(c *cli.Context) error {
 		return errors.Wrap(err, "could not compute owner ID")
 	}
 
-	resp, err := accounting.NewWithdrawClient(conn).List(ctx, &accounting.ListRequest{
-		OwnerID: owner,
-		TTL:     getTTL(c),
-	})
+	req := &accounting.ListRequest{OwnerID: owner}
+	req.SetTTL(getTTL(c))
+	resp, err := accounting.NewWithdrawClient(conn).List(ctx, req)
 	if err != nil {
 		return errors.Wrapf(err, "can't complete request")
 	}

--- a/withdraw.go
+++ b/withdraw.go
@@ -78,7 +78,7 @@ func putWithdraw(c *cli.Context) error {
 	}
 
 	// Try to receive key from file
-	if key, err = parseKeyValue(keyArg); err != nil {
+	if key, err = crypto.LoadPrivateKey(keyArg); err != nil {
 		return err
 	}
 
@@ -141,7 +141,7 @@ func getWithdraw(c *cli.Context) error {
 	}
 
 	// Try to receive key from file
-	if key, err = parseKeyValue(keyArg); err != nil {
+	if key, err = crypto.LoadPrivateKey(keyArg); err != nil {
 		return err
 	}
 
@@ -243,7 +243,7 @@ func delWithdraw(c *cli.Context) error {
 	}
 
 	// Try to receive key from file
-	if key, err = parseKeyValue(keyArg); err != nil {
+	if key, err = crypto.LoadPrivateKey(keyArg); err != nil {
 		return err
 	}
 
@@ -296,7 +296,7 @@ func listWithdraw(c *cli.Context) error {
 	}
 
 	// Try to receive key from file
-	if key, err = parseKeyValue(keyArg); err != nil {
+	if key, err = crypto.LoadPrivateKey(keyArg); err != nil {
 		return err
 	}
 

--- a/withdraw.go
+++ b/withdraw.go
@@ -15,7 +15,6 @@ import (
 	"github.com/nspcc-dev/neofs-proto/accounting"
 	"github.com/nspcc-dev/neofs-proto/decimal"
 	"github.com/nspcc-dev/neofs-proto/refs"
-	"github.com/nspcc-dev/neofs-proto/service"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 	"google.golang.org/grpc"
@@ -30,7 +29,6 @@ var (
 	putWithdrawAction = &action{
 		Action: putWithdraw,
 		Flags: []cli.Flag{
-			keyFile,
 			blockHeight,
 			amount,
 		},
@@ -38,47 +36,36 @@ var (
 	getWithdrawAction = &action{
 		Action: getWithdraw,
 		Flags: []cli.Flag{
-			keyFile,
 			withdrawID,
 		},
 	}
 	delWithdrawAction = &action{
 		Action: delWithdraw,
 		Flags: []cli.Flag{
-			keyFile,
 			withdrawID,
 		},
 	}
 
 	listWithdrawAction = &action{
 		Action: listWithdraw,
-		Flags: []cli.Flag{
-			keyFile,
-		},
 	}
 )
 
 func putWithdraw(c *cli.Context) error {
 	var (
 		err   error
-		key   *ecdsa.PrivateKey
+		key   = getKey(c)
 		conn  *grpc.ClientConn
 		msgID refs.MessageID
 
 		host        = c.Parent().String(hostFlag)
-		keyArg      = c.String(keyFlag)
 		amount      = c.Float64(amountFlag)
 		blockHeight = c.Uint64(heightFlag)
 	)
 
-	if host == "" || keyArg == "" {
+	if host == "" {
 		return errors.Errorf("invalid input\nUsage: %s", c.Command.UsageText)
 	} else if host, err = parseHostValue(host); err != nil {
-		return err
-	}
-
-	// Try to receive key from file
-	if key, err = crypto.LoadPrivateKey(keyArg); err != nil {
 		return err
 	}
 
@@ -107,11 +94,8 @@ func putWithdraw(c *cli.Context) error {
 		Height:    blockHeight,
 		MessageID: msgID,
 	}
-	req.SetTTL(getTTL(c))
-
-	if err = service.SignRequest(req, key); err != nil {
-		return errors.Wrap(err, "could not sign request")
-	}
+	setTTL(c, req)
+	signRequest(c, req)
 
 	resp, err := accounting.NewWithdrawClient(conn).Put(ctx, req)
 	if err != nil {
@@ -161,7 +145,8 @@ func getWithdraw(c *cli.Context) error {
 		ID:      accounting.ChequeID(wid),
 		OwnerID: owner,
 	}
-	req.SetTTL(getTTL(c))
+	setTTL(c, req)
+	signRequest(c, req)
 	resp, err := accounting.NewWithdrawClient(conn).Get(ctx, req)
 	if err != nil {
 		return errors.Wrap(err, "can't perform request")
@@ -268,11 +253,8 @@ func delWithdraw(c *cli.Context) error {
 		OwnerID:   owner,
 		MessageID: msgID,
 	}
-	req.SetTTL(getTTL(c))
-
-	if err = service.SignRequest(req, key); err != nil {
-		return errors.Wrap(err, "could not sign request")
-	}
+	setTTL(c, req)
+	signRequest(c, req)
 
 	_, err = accounting.NewWithdrawClient(conn).Delete(ctx, req)
 
@@ -313,7 +295,9 @@ func listWithdraw(c *cli.Context) error {
 	}
 
 	req := &accounting.ListRequest{OwnerID: owner}
-	req.SetTTL(getTTL(c))
+	setTTL(c, req)
+	signRequest(c, req)
+
 	resp, err := accounting.NewWithdrawClient(conn).List(ctx, req)
 	if err != nil {
 		return errors.Wrapf(err, "can't complete request")


### PR DESCRIPTION
- Updated neofs-crypto (v0.2.2) and neofs-proto (v0.2.0) to new releases
- Used `crypto.LoadPrivateKey` instead of `parseKeyValue`
- TTL field was replaced with RequestMetaHeader