### PR TITLE
object: fix get-range-hash

### DIFF
--- a/object.go
+++ b/object.go
@@ -461,8 +461,11 @@ func getRangeHash(c *cli.Context) error {
 			if _, err = fd.ReadAt(d, int64(ranges[i].Offset)); err != nil && err != io.EOF {
 				return errors.Wrap(err, "could not read range from file")
 			}
+
+			xor := hash.SaltXOR(d[:ranges[i].Length], salt)
+
 			fmt.Print("(")
-			if !hash.Sum(d[:ranges[i].Length]).Equal(resp.Hashes[i]) {
+			if !hash.Sum(xor).Equal(resp.Hashes[i]) {
 				fmt.Print("in")
 			}
 			fmt.Print("valid) ")


### PR DESCRIPTION
```
→ go run ./ object get-range-hash \
> --cid rBD6QbewoR2sMnqQxamAxoZhTRPtWu18RoGJZtry7mU \
> --oid 472d1c75-3c8c-44b9-9700-d410d2ab0aee \
> --verify \
> --file ./go.mod \
> --salt 01020304 4:10

(valid) 111115VUn5VCYxoXFoifYQwHbYWyystNgPF9HPjaruyktgjetN6jCVA8AFyjopdMrLRXZTp2J2HENwBNGnyVy
```