### PR TITLE
Use beforeAction to set default config for `set` command

### DIFF
--- a/config.go
+++ b/config.go
@@ -35,8 +35,6 @@ const (
 func beforeAction(c *cli.Context) error {
 	if args := c.Args(); args.Len() == 0 { // ignore help command
 		return nil
-	} else if args.First() == "set" { // ignore set command
-		return nil
 	}
 
 	// do something before command


### PR DESCRIPTION
Set command can't save config without beforeAction routine.
This routine sets default config file name into viper instance,
therefore `WriteConfig()` will not return error.

Right now it is impossible to save config into the file
```
$ ./bin/neofs-cli set key ./user.key 
set new value for key: "./user.key"
Config File "config" Not Found in "[]"
```