### PR TITLE
In go 1.13 was added build flag `-trimpath`

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,6 +16,7 @@ builds:
       - amd64
     flags:
       - -mod=vendor
+      - -trimpath
     ldflags:
       - -w -s -X main.Version={{.Version}} -X main.Build={{ time "2006-01-02T15:04:05" }}
 archives:

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /src
 
 COPY . /src
 
-RUN go build -v -mod=vendor -ldflags "${LDFLAGS}" -o /go/bin/neofs-cli ./
+RUN go build -v -mod=vendor -trimpath -ldflags "${LDFLAGS}" -o /go/bin/neofs-cli ./
 
 # Executable image
 FROM alpine:3.10 AS neofs-cli


### PR DESCRIPTION
```
The new go build flag -trimpath removes all file system paths from the compiled 
executable, to improve build reproducibility.

If the -o flag passed to go build refers to an existing directory, go build will now
write executable files within that directory for main packages matching its 
package arguments.

The go build flag -tags now takes a comma-separated list of build tags, to allow
for multiple tags in GOFLAGS. The space-separated form is deprecated but still
recognized and will be maintained.
```