### PR TITLE
Add method to dump debug variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,21 @@ $ ./bin/neofs-cli --host fs.nspcc.ru:8080 --key /key status config
 }
 ```
 
+#### Request runtime debug variables
+
+*Node must be configured to grant access for certain users. Authentication is made by passed key.*
+
+```
+$ ./bin/neofs-cli --host fs.nspcc.ru:8080 --key /key status dump_vars
+{...} // variables in ugly json (without formatting)
+
+$ ./bin/neofs-cli --host fs.nspcc.ru:8080 --key /key status dump_vars --beauty
+// variables in json with formatting
+{
+  // ...
+}
+```
+
 ## License
 
 This project is licensed under the GPLv3 License - 

--- a/action.go
+++ b/action.go
@@ -46,6 +46,7 @@ const (
 	GetMetrics
 	GetHealthy
 	GetConfig
+	GetDebugVars
 )
 
 type action struct {
@@ -93,12 +94,13 @@ var actions = map[actionName]*action{
 	BalanceAccounting: getBalanceAction,
 
 	// status commands
-	Status:     statusAction,
-	GetEpoch:   epochAction,
-	GetNetmap:  netmapAction,
-	GetMetrics: metricsAction,
-	GetHealthy: healthyAction,
-	GetConfig:  configAction,
+	Status:       statusAction,
+	GetEpoch:     epochAction,
+	GetNetmap:    netmapAction,
+	GetMetrics:   metricsAction,
+	GetHealthy:   healthyAction,
+	GetConfig:    configAction,
+	GetDebugVars: dumpVarsAction,
 }
 
 func getFlags(name actionName) []cli.Flag {

--- a/commands.go
+++ b/commands.go
@@ -270,6 +270,14 @@ func commands() cli.Commands {
 					Flags:       getFlags(GetConfig),
 					Action:      getAction(GetConfig),
 				},
+				{
+					Name:        "dump_vars",
+					Usage:       "dump debug variables of specified node",
+					UsageText:   "neofs-cli --host <host:port> --key <key:path|hex|wif> status dump_vars",
+					Description: "allows dumping debug variables of specified node",
+					Flags:       getFlags(GetDebugVars),
+					Action:      getAction(GetDebugVars),
+				},
 			},
 		},
 	}

--- a/flags.go
+++ b/flags.go
@@ -24,6 +24,7 @@ const (
 	amountFlag  = "amount"
 	sgFlag      = "sg"
 	verboseFlag = "verbose"
+	beautyFlag  = "beauty"
 
 	ConfigFlag = "config"
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/mr-tron/base58 v1.1.3
-	github.com/nspcc-dev/neofs-api v0.3.1
+	github.com/nspcc-dev/neofs-api v0.3.2
 	github.com/nspcc-dev/neofs-crypto v0.2.3
 	github.com/nspcc-dev/netmap v1.6.1
 	github.com/nspcc-dev/netmap-ql v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -118,8 +118,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/nspcc-dev/hrw v1.0.1/go.mod h1:2gbvQ0nRi9+er+djibFyMLMWC8Ilwe7Z9pYCU6OrkMM=
 github.com/nspcc-dev/hrw v1.0.8 h1:vwRuJXZXgkMvf473vFzeWGCfY1WBVeSHAEHvR4u3/Cg=
 github.com/nspcc-dev/hrw v1.0.8/go.mod h1:l/W2vx83vMQo6aStyx2AuZrJ+07lGv2JQGlVkPG06MU=
-github.com/nspcc-dev/neofs-api v0.3.1 h1:QbaTcBTUXWjihMR5kw+UPvCjzmLx6g5m3qDvyhyBmzE=
-github.com/nspcc-dev/neofs-api v0.3.1/go.mod h1:Y1PQ6nEZyA6sZPDHJxgPWWeT1oU2bKL1N0rpFQ4B/fk=
+github.com/nspcc-dev/neofs-api v0.3.2 h1:w5s7rqnv0wwh+BpSrSlxpTTiQzzjryTigcPFxn6cxJc=
+github.com/nspcc-dev/neofs-api v0.3.2/go.mod h1:Y1PQ6nEZyA6sZPDHJxgPWWeT1oU2bKL1N0rpFQ4B/fk=
 github.com/nspcc-dev/neofs-crypto v0.2.3 h1:aca3X2aly92ENRbFK+kH6Hd+J9EQ4Eu6XMVoITSIKtc=
 github.com/nspcc-dev/neofs-crypto v0.2.3/go.mod h1:8w16GEJbH6791ktVqHN9YRNH3s9BEEKYxGhlFnp0cDw=
 github.com/nspcc-dev/netmap v1.2.0/go.mod h1:9vt5vDTHP0BdhUluQek4iFfMv+pCv5b1Kg7eM6WyQl8=


### PR DESCRIPTION
- Update to NeoFS API v0.3.2
- Implement action to dump debug variables

*For newest nodes:*

```
$ ./neofs-cli status dump_vars 
{
  // Debug variables of the node without formatting output
}
```

```
$ ./neofs-cli status dump_vars --beauty
{
  // Debug variables of the node with formatting output
}
```

*For older nodes:*

```
$ ./neofs-cli status dump_vars 
Unimplemented: unknown method DumpVars for service state.Status
```