### PR TITLE
Add support of basic ACL in the container

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/mr-tron/base58 v1.1.3
-	github.com/nspcc-dev/neofs-api-go v0.5.0
+	github.com/nspcc-dev/neofs-api-go v0.6.0
 	github.com/nspcc-dev/neofs-crypto v0.3.0
 	github.com/nspcc-dev/netmap v1.7.0
 	github.com/nspcc-dev/netmap-ql v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -118,8 +118,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/nspcc-dev/hrw v1.0.1/go.mod h1:2gbvQ0nRi9+er+djibFyMLMWC8Ilwe7Z9pYCU6OrkMM=
 github.com/nspcc-dev/hrw v1.0.8 h1:vwRuJXZXgkMvf473vFzeWGCfY1WBVeSHAEHvR4u3/Cg=
 github.com/nspcc-dev/hrw v1.0.8/go.mod h1:l/W2vx83vMQo6aStyx2AuZrJ+07lGv2JQGlVkPG06MU=
-github.com/nspcc-dev/neofs-api-go v0.5.0 h1:YGX2lEjFmiFYmk8gCkLINJjSh6hToKp2oo0sG5u8G+4=
-github.com/nspcc-dev/neofs-api-go v0.5.0/go.mod h1:RlP++uLPHmXN81KWmdgBujo6FEeTn/b3aoQjHgKuNd4=
+github.com/nspcc-dev/neofs-api-go v0.6.0 h1:0m+WiIcY6nd4P70lKpTUqOEEaR4RG+hAcjLXg2sUCCw=
+github.com/nspcc-dev/neofs-api-go v0.6.0/go.mod h1:RlP++uLPHmXN81KWmdgBujo6FEeTn/b3aoQjHgKuNd4=
 github.com/nspcc-dev/neofs-crypto v0.3.0 h1:zlr3pgoxuzrmGCxc5W8dGVfA9Rro8diFvVnBg0L4ifM=
 github.com/nspcc-dev/neofs-crypto v0.3.0/go.mod h1:8w16GEJbH6791ktVqHN9YRNH3s9BEEKYxGhlFnp0cDw=
 github.com/nspcc-dev/netmap v1.2.0/go.mod h1:9vt5vDTHP0BdhUluQek4iFfMv+pCv5b1Kg7eM6WyQl8=


### PR DESCRIPTION
Basic ACL stored in the the container structure as 32-bit mask. NeoFS nodes use this ACL to provide access for object service operations.

Set basic acl with `--acl` flag in container command:
```
$ neofs-cli container put --rule 'SELECT 2 Node' --acl 0x188888FF
```
If you omit this flag then default ACL is set. Default ACL gives all permissions for everyone: `0x1FFFFFFF`.