### PR TITLE
Update to neofs-api-go v0.7.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ GLOBAL OPTIONS:
    --verbose       verbose gRPC connection (default: false)
    --help, -h      show help (default: false)
    --version, -v   print the version (default: false)
+   --raw value     use raw request (default: false)
 
 ```
 ### Configuration

--- a/accounting.go
+++ b/accounting.go
@@ -41,6 +41,7 @@ func getBalance(c *cli.Context) error {
 
 	req := &accounting.BalanceRequest{OwnerID: owner}
 	setTTL(c, req)
+	setRaw(c, req)
 	signRequest(c, req)
 
 	resp, err := accounting.NewAccountingClient(conn).Balance(ctx, req)

--- a/action.go
+++ b/action.go
@@ -57,7 +57,7 @@ type action struct {
 
 var actions = map[actionName]*action{
 	Global: {
-		Flags: []cli.Flag{ttlF, cfgF, keyFile, hostAddr, verbose},
+		Flags: []cli.Flag{ttlF, rawQuery, cfgF, keyFile, hostAddr, verbose},
 	},
 
 	// container commands

--- a/commands.go
+++ b/commands.go
@@ -43,7 +43,7 @@ func commands() cli.Commands {
 				{
 					Name:        "get",
 					Usage:       "get object from container",
-					UsageText:   "get --cid <cid> --oid <oid> --file ./my-file [--perm <permissions>] [--raw]",
+					UsageText:   "get --cid <cid> --oid <oid> --file ./my-file [--perm <permissions>]",
 					Description: "get file from network",
 					Flags:       getFlags(GetObject),
 					Action:      getAction(GetObject),
@@ -59,7 +59,7 @@ func commands() cli.Commands {
 				{
 					Name:        "head",
 					Usage:       "get object header from container",
-					UsageText:   "head --cid <cid> --oid <oid> [--full-headers] [--raw]",
+					UsageText:   "head --cid <cid> --oid <oid> [--full-headers]",
 					Description: "retrieve object metadata",
 					Flags:       getFlags(HeadObject),
 					Action:      getAction(HeadObject),

--- a/container.go
+++ b/container.go
@@ -127,6 +127,7 @@ func putContainer(c *cli.Context) error {
 	}
 
 	setTTL(c, req)
+	setRaw(c, req)
 	signRequest(c, req)
 
 	resp, err := container.NewServiceClient(conn).Put(ctx, req)
@@ -157,6 +158,7 @@ loop:
 
 			req := &container.ListRequest{OwnerID: owner}
 			setTTL(c, req)
+			setRaw(c, req)
 			signRequest(c, req)
 
 			resp, err := client.List(ctx, req)
@@ -180,6 +182,7 @@ loop:
 func fetchContainer(ctx context.Context, con *grpc.ClientConn, cid refs.CID, cli *cli.Context) (*container.GetResponse, error) {
 	req := &container.GetRequest{CID: cid}
 	setTTL(cli, req)
+	setRaw(cli, req)
 	signRequest(cli, req)
 	return container.NewServiceClient(con).Get(ctx, req)
 }
@@ -244,6 +247,7 @@ func delContainer(c *cli.Context) error {
 
 	req := &container.DeleteRequest{CID: cid}
 	setTTL(c, req)
+	setRaw(c, req)
 	signRequest(c, req)
 
 	_, err = container.NewServiceClient(conn).Delete(ctx, req)
@@ -271,6 +275,7 @@ func listContainers(c *cli.Context) error {
 
 	req := &container.ListRequest{OwnerID: owner}
 	setTTL(c, req)
+	setRaw(c, req)
 	signRequest(c, req)
 
 	resp, err := container.NewServiceClient(conn).List(ctx, req)

--- a/flags.go
+++ b/flags.go
@@ -134,9 +134,9 @@ var (
 	}
 )
 
-func signRequest(c *cli.Context, req service.VerifiableRequest) {
+func signRequest(c *cli.Context, req service.DataWithTokenSignAccumulator) {
 	key := getKey(c)
-	if err := service.SignRequestHeader(key, req); err != nil {
+	if err := service.SignDataWithSessionToken(key, req); err != nil {
 		fmt.Printf("%T could not sign request\n", req)
 		fmt.Println(err.Error())
 		os.Exit(2)
@@ -180,7 +180,7 @@ func getKey(c *cli.Context) *ecdsa.PrivateKey {
 	return key
 }
 
-func setTTL(c *cli.Context, req service.MetaHeader) {
+func setTTL(c *cli.Context, req service.TTLContainer) {
 	ttl := c.Uint(ttlFlag)
 	req.SetTTL(uint32(ttl))
 }

--- a/flags.go
+++ b/flags.go
@@ -184,3 +184,9 @@ func setTTL(c *cli.Context, req service.TTLContainer) {
 	ttl := c.Uint(ttlFlag)
 	req.SetTTL(uint32(ttl))
 }
+
+func setRaw(c *cli.Context, req service.RawContainer) {
+	req.SetRaw(
+		c.Bool(rawFlag),
+	)
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/mr-tron/base58 v1.1.3
-	github.com/nspcc-dev/neofs-api-go v0.7.1
+	github.com/nspcc-dev/neofs-api-go v0.7.6
 	github.com/nspcc-dev/neofs-crypto v0.3.0
 	github.com/nspcc-dev/netmap v1.7.0
 	github.com/nspcc-dev/netmap-ql v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/nspcc-dev/hrw v1.0.1/go.mod h1:2gbvQ0nRi9+er+djibFyMLMWC8Ilwe7Z9pYCU6OrkMM=
 github.com/nspcc-dev/hrw v1.0.8 h1:vwRuJXZXgkMvf473vFzeWGCfY1WBVeSHAEHvR4u3/Cg=
 github.com/nspcc-dev/hrw v1.0.8/go.mod h1:l/W2vx83vMQo6aStyx2AuZrJ+07lGv2JQGlVkPG06MU=
-github.com/nspcc-dev/neofs-api-go v0.7.1 h1:Q26tsfJN9vLyAaJHPYr/ism8VOWRdMYPnIO9QeNrwKQ=
-github.com/nspcc-dev/neofs-api-go v0.7.1/go.mod h1:fzV1gSigr5sEYWjs1jL395Cyv+6y/dMk2PeVPv+Vqlo=
+github.com/nspcc-dev/neofs-api-go v0.7.6 h1:OBEKbFcf0fxujB9m23fB0EvwtHyud1Fs2wkalP3mDJo=
+github.com/nspcc-dev/neofs-api-go v0.7.6/go.mod h1:fzV1gSigr5sEYWjs1jL395Cyv+6y/dMk2PeVPv+Vqlo=
 github.com/nspcc-dev/neofs-crypto v0.3.0 h1:zlr3pgoxuzrmGCxc5W8dGVfA9Rro8diFvVnBg0L4ifM=
 github.com/nspcc-dev/neofs-crypto v0.3.0/go.mod h1:8w16GEJbH6791ktVqHN9YRNH3s9BEEKYxGhlFnp0cDw=
 github.com/nspcc-dev/netmap v1.2.0/go.mod h1:9vt5vDTHP0BdhUluQek4iFfMv+pCv5b1Kg7eM6WyQl8=

--- a/object.go
+++ b/object.go
@@ -342,11 +342,11 @@ func objectStringify(dst io.Writer, obj *object.Object) error {
 				buf.WriteByte('}')
 				val = buf.String()
 			}
-		case *object.Header_Verify:
-			key = "Verify"
-			val = fmt.Sprintf("{PublicKey=%02x Signature=%02x}",
-				t.Verify.PublicKey,
-				t.Verify.KeySignature)
+		case *object.Header_Token:
+			key = "Token"
+			val = fmt.Sprintf("{ID=%s Verb=%s}",
+				t.Token.GetID(),
+				t.Token.GetVerb())
 		case *object.Header_PublicKey:
 			key = "PublicKey"
 			val = hex.EncodeToString(t.PublicKey.Value)

--- a/object.go
+++ b/object.go
@@ -97,7 +97,6 @@ var (
 			objectID,
 			filePath,
 			permissions,
-			rawQuery,
 		},
 	}
 	delObjectAction = &action{
@@ -113,7 +112,6 @@ var (
 			containerID,
 			objectID,
 			fullHeaders,
-			rawQuery,
 		},
 	}
 	searchObjectAction = &action{
@@ -214,6 +212,7 @@ func del(c *cli.Context) error {
 	}
 	req.SetToken(token)
 	setTTL(c, req)
+	setRaw(c, req)
 	signRequest(c, req)
 
 	_, err = object.NewServiceClient(conn).Delete(ctx, req)
@@ -236,7 +235,6 @@ func head(c *cli.Context) error {
 		objArg = c.String(objFlag)
 		fh     = c.Bool(fullHeadersFlag)
 		ctx    = gracefulContext()
-		raw    = c.Bool(rawFlag)
 	)
 
 	if cidArg == "" || objArg == "" {
@@ -280,8 +278,8 @@ func head(c *cli.Context) error {
 		FullHeaders: fh,
 	}
 	req.SetToken(token)
-	req.SetRaw(raw)
 	setTTL(c, req)
+	setRaw(c, req)
 	signRequest(c, req)
 
 	resp, err := object.NewServiceClient(conn).Head(ctx, req)
@@ -490,6 +488,7 @@ func search(c *cli.Context) error {
 	}
 	req.SetToken(token)
 	setTTL(c, req)
+	setRaw(c, req)
 	signRequest(c, req)
 
 	searchClient, err := object.NewServiceClient(conn).Search(ctx, req)
@@ -582,6 +581,7 @@ func getRange(c *cli.Context) error {
 	}
 	req.SetToken(token)
 	setTTL(c, req)
+	setRaw(c, req)
 	signRequest(c, req)
 
 	rangeClient, err := object.NewServiceClient(conn).GetRange(ctx, req)
@@ -677,6 +677,7 @@ func getRangeHash(c *cli.Context) error {
 	}
 	req.SetToken(token)
 	setTTL(c, req)
+	setRaw(c, req)
 	signRequest(c, req)
 
 	resp, err := object.NewServiceClient(conn).GetRangeHash(ctx, req)
@@ -843,6 +844,7 @@ func put(c *cli.Context) error {
 		}
 		req.SetToken(token)
 		setTTL(c, req)
+		setRaw(c, req)
 		signRequest(c, req)
 
 		if err = putClient.Send(req); err != nil {
@@ -863,6 +865,7 @@ func put(c *cli.Context) error {
 
 				req := object.MakePutRequestChunk(data[:n])
 				setTTL(c, req)
+				setRaw(c, req)
 				signRequest(c, req)
 
 				if err := putClient.Send(req); err != nil && err != io.EOF {
@@ -904,6 +907,7 @@ func put(c *cli.Context) error {
 			}
 			req.SetToken(token)
 			setTTL(c, req)
+			setRaw(c, req)
 			signRequest(c, req)
 
 			if r, err := client.GetRangeHash(ctx, req); err != nil {
@@ -1001,7 +1005,6 @@ func get(c *cli.Context) error {
 		sOID  = c.String(objFlag)
 		fPath = c.String(fileFlag)
 		perm  = c.Int(permFlag)
-		raw   = c.Bool(rawFlag)
 		ctx   = gracefulContext()
 	)
 
@@ -1045,8 +1048,8 @@ func get(c *cli.Context) error {
 		Address: addr,
 	}
 	req.SetToken(token)
-	req.SetRaw(raw)
 	setTTL(c, req)
+	setRaw(c, req)
 	signRequest(c, req)
 
 	getClient, err := object.NewServiceClient(conn).Get(ctx, req)

--- a/object_test.go
+++ b/object_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/nspcc-dev/neofs-api-go/object"
 	"github.com/nspcc-dev/neofs-api-go/refs"
+	"github.com/nspcc-dev/neofs-api-go/service"
 	"github.com/nspcc-dev/neofs-api-go/storagegroup"
 	"github.com/nspcc-dev/neofs-crypto/test"
 	"github.com/stretchr/testify/require"
@@ -31,8 +32,8 @@ func TestStringify(t *testing.T) {
 		  Value=Split
 		- Type=Tombstone
 		  Value=MARKED
-		- Type=Verify
-		  Value={PublicKey=010203040506 Signature=010203040506}
+		- Type=Token
+		  Value={ID=01020304-0506-0000-0000-000000000000 Verb=Put}
 		- Type=HomoHash
 		  Value=00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
 		- Type=PayloadChecksum
@@ -110,13 +111,14 @@ func TestStringify(t *testing.T) {
 		},
 	})
 
-	// *Header_Verify
+	// *Header_Token
+	token := new(service.Token)
+	token.SetID(service.TokenID{1, 2, 3, 4, 5, 6})
+	token.SetVerb(service.Token_Info_Put)
+
 	obj.Headers = append(obj.Headers, object.Header{
-		Value: &object.Header_Verify{
-			Verify: &object.VerificationHeader{
-				PublicKey:    []byte{1, 2, 3, 4, 5, 6},
-				KeySignature: []byte{1, 2, 3, 4, 5, 6},
-			},
+		Value: &object.Header_Token{
+			Token: token,
 		},
 	})
 

--- a/status.go
+++ b/status.go
@@ -74,6 +74,7 @@ func changeState(c *cli.Context) error {
 	}
 
 	req.SetTTL(service.NonForwardingTTL)
+	setRaw(c, req)
 	signRequest(c, req)
 
 	if _, err = state.NewStatusClient(conn).ChangeState(ctx, req); err != nil {
@@ -99,6 +100,7 @@ func getVars(c *cli.Context) error {
 	}
 
 	req.SetTTL(service.NonForwardingTTL)
+	setRaw(c, req)
 	signRequest(c, req)
 
 	res, err := state.NewStatusClient(conn).DumpVars(ctx, req)
@@ -135,6 +137,7 @@ func getConfig(c *cli.Context) error {
 	}
 
 	req.SetTTL(service.NonForwardingTTL)
+	setRaw(c, req)
 	signRequest(c, req)
 
 	res, err := state.NewStatusClient(conn).DumpConfig(ctx, req)
@@ -161,6 +164,7 @@ func getMetrics(c *cli.Context) error {
 	}
 
 	setTTL(c, req)
+	setRaw(c, req)
 	signRequest(c, req)
 
 	res, err := state.NewStatusClient(conn).Metrics(ctx, req)
@@ -199,6 +203,7 @@ func getHealthy(c *cli.Context) error {
 	}
 
 	setTTL(c, req)
+	setRaw(c, req)
 	signRequest(c, req)
 
 	res, err := state.NewStatusClient(conn).HealthCheck(ctx, req)
@@ -225,6 +230,7 @@ func getEpoch(c *cli.Context) error {
 	}
 
 	setTTL(c, req)
+	setRaw(c, req)
 	signRequest(c, req)
 
 	nm, err := state.NewStatusClient(conn).Netmap(ctx, req)
@@ -250,6 +256,7 @@ func getNetmap(c *cli.Context) error {
 	}
 
 	setTTL(c, req)
+	setRaw(c, req)
 	signRequest(c, req)
 
 	nm, err := state.NewStatusClient(conn).Netmap(ctx, req)

--- a/storagegroup.go
+++ b/storagegroup.go
@@ -19,7 +19,6 @@ var (
 		Action: getSG,
 		Flags: []cli.Flag{
 			containerID,
-			rawQuery,
 			storagegroupID,
 			oidHidden,
 			fullHeadersHidden,
@@ -35,7 +34,6 @@ var (
 		Action: delSG,
 		Flags: []cli.Flag{
 			containerID,
-			rawQuery,
 			storagegroupID,
 			oidHidden,
 			fullHeadersHidden,
@@ -176,6 +174,7 @@ func putSG(c *cli.Context) error {
 	req := object.MakePutRequestHeader(sg)
 	req.SetToken(token)
 	setTTL(c, req)
+	setRaw(c, req)
 	signRequest(c, req)
 
 	if err = putClient.Send(req); err != nil {

--- a/storagegroup.go
+++ b/storagegroup.go
@@ -2,11 +2,10 @@ package main
 
 import (
 	"fmt"
-	"math"
 
 	"github.com/nspcc-dev/neofs-api-go/object"
 	"github.com/nspcc-dev/neofs-api-go/refs"
-	"github.com/nspcc-dev/neofs-api-go/session"
+	"github.com/nspcc-dev/neofs-api-go/service"
 	"github.com/nspcc-dev/neofs-api-go/storagegroup"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
@@ -150,18 +149,22 @@ func putSG(c *cli.Context) error {
 
 	sg.SystemHeader.ID = objID
 
-	token, err := establishSession(ctx, sessionParams{
-		cmd:  c,
-		key:  key,
-		conn: conn,
-		token: &session.Token{
-			// FirstEpoch: 0,
-			ObjectID:  []refs.ObjectID{objID},
-			LastEpoch: math.MaxUint64,
+	token, err := createToken(tokenParams{
+		connectionParams: connectionParams{
+			ctx:  ctx,
+			cmd:  c,
+			conn: conn,
 		},
+
+		addr: refs.Address{
+			ObjectID: objID,
+			CID:      cid,
+		},
+
+		verb: service.Token_Info_Put,
 	})
 	if err != nil {
-		return errors.Wrap(err, "can't establish session")
+		return errors.Wrap(err, "could not create session token")
 	}
 
 	client := object.NewServiceClient(conn)
@@ -170,7 +173,8 @@ func putSG(c *cli.Context) error {
 		return errors.Wrap(err, "put command failed on client creation")
 	}
 
-	req := object.MakePutRequestHeader(sg, token)
+	req := object.MakePutRequestHeader(sg)
+	req.SetToken(token)
 	setTTL(c, req)
 	signRequest(c, req)
 

--- a/withdraw.go
+++ b/withdraw.go
@@ -84,6 +84,7 @@ func putWithdraw(c *cli.Context) error {
 		MessageID: msgID,
 	}
 	setTTL(c, req)
+	setRaw(c, req)
 	signRequest(c, req)
 
 	resp, err := accounting.NewWithdrawClient(conn).Put(ctx, req)
@@ -124,6 +125,7 @@ func getWithdraw(c *cli.Context) error {
 		OwnerID: owner,
 	}
 	setTTL(c, req)
+	setRaw(c, req)
 	signRequest(c, req)
 	resp, err := accounting.NewWithdrawClient(conn).Get(ctx, req)
 	if err != nil {
@@ -221,6 +223,7 @@ func delWithdraw(c *cli.Context) error {
 		MessageID: msgID,
 	}
 	setTTL(c, req)
+	setRaw(c, req)
 	signRequest(c, req)
 
 	_, err = accounting.NewWithdrawClient(conn).Delete(ctx, req)
@@ -248,6 +251,7 @@ func listWithdraw(c *cli.Context) error {
 
 	req := &accounting.ListRequest{OwnerID: owner}
 	setTTL(c, req)
+	setRaw(c, req)
 	signRequest(c, req)
 
 	resp, err := accounting.NewWithdrawClient(conn).List(ctx, req)


### PR DESCRIPTION
Summary:

- use a new approach request signing;

- use a new approach of session establishing;

- move `Raw` option to global flags;

- replace `Header_Verify` case with `Header_Token` in `objectStringify`.