### PR TITLE
Return error for Tombstone objects (marked as deleted)

### DIFF
--- a/object.go
+++ b/object.go
@@ -1078,8 +1078,7 @@ func get(c *cli.Context) error {
 					fmt.Println("Object corrupted")
 					return err
 				}
-				fmt.Println("Object removed")
-				return nil
+				return errors.New("Object removed")
 			}
 
 			fmt.Printf("Object origin received: %s\n", resp.GetObject().SystemHeader.ID)


### PR DESCRIPTION
fix #41

```
→ go run ./ object get --cid 2UVmqy55d7YpiwxmzHEhMsZHkgEwtEw187dTX3PcdbSv --oid ee4552a7-a978-48d0-95ce-dc9470d08ac2 --file /tmp/test-file.jpg
Waiting for data...
Object origin received: ee4552a7-a978-48d0-95ce-dc9470d08ac2
receiving chunks: #
Object successfully fetched

→ go run ./ object delete --cid 2UVmqy55d7YpiwxmzHEhMsZHkgEwtEw187dTX3PcdbSv --oid ee4552a7-a978-48d0-95ce-dc9470d08ac2

→ go run ./ object get --cid 2UVmqy55d7YpiwxmzHEhMsZHkgEwtEw187dTX3PcdbSv --oid ee4552a7-a978-48d0-95ce-dc9470d08ac2 --file /tmp/test-file.jpg
Waiting for data...
Object removed
exit status 2
```